### PR TITLE
Popup warning too verbose

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -60,7 +60,7 @@ Formatter.prototype._comb = function(config) {
 		}
 	}
 
-	vscode.window.showWarningMessage('Cannot execute CSScomb because there is not style files.');
+	console.error('Cannot execute CSScomb because there is not style files.');
 	return false;
 };
 


### PR DESCRIPTION
Removed popup warning when we try to format a file that is not a style file (css, etc). console.error(...) should be sufficient.
This is important because if you keybind this extensions format command you will get the warning popup when you format other files which is not what you want, you just want to format whatever file you're in with another formatter as expected.