### PR TITLE
fix for issue #112

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,12 +110,13 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 
 		const actions = provider.format().then((blocks) => {
-			return blocks.map((block) => {
-				if (block.error) {
-					showOutput(block.error.toString());
-				}
-
-				return vscode.TextEdit.replace(block.range, block.content);
+			vscode.window.activeTextEditor.edit((builder) => {
+				blocks.forEach((block) => {
+					if (block.error) {
+						showOutput(block.error.toString());
+					}
+					builder.replace(block.range, block.content);
+				});
 			});
 		}).catch((err: Error) => showOutput(err.stack));
 


### PR DESCRIPTION
### What is the purpose of this pull request?

This PR is intented to resolve issue #112 ie. preserving cursor position and section folding when using `"csscomb.formatOnSave": true,`

### What changes did you make? (Give an overview)

copy/paste of the code running when using Command Palette "CSSComb: format styles" (onCommand) into the code running when saving file (`onSave`).
There definitely should be some refactoring to do but since I'm not sure of what I'm really doing, I prefer leaving as is, since it seems to be working. 🎉 
