### PR TITLE
Update details in Usage and csscomb.preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ See the [extension installation guide](https://code.visualstudio.com/docs/editor
 
 ## Usage
 
-Press <kbd>F1</kbd> and run the command named `CSSComb`.
+1. Put a `cssconfig.json` in your project root, or set the config in the setting `csscomb.preset`. You can start with one of the [predefined configs](https://github.com/csscomb/csscomb.js/tree/dev/config) or [generate a config](http://csscomb.com/config). See details in [config docs](https://github.com/csscomb/csscomb.js/blob/dev/doc/configuration.md).
+1. Run `CSSComb` in the Command Palette (<kbd>F1</kbd>, <kbd>Ctrl+Shift+P</kbd> on Windows, <kbd>Cmd+Shift+P</kbd> on macOS).
 
 ## Supported languages
 
@@ -34,8 +35,9 @@ Press <kbd>F1</kbd> and run the command named `CSSComb`.
 
   * Type: `Object` or `String`
   * Defaut: `{}`
+  * Example: `'~/path/to/file/csscomb.json'` or `'csscomb'`
 
-Config's name. Should be one of the following: `csscomb`, `zen`, `yandex` or an object containing custom configuration or path to config. You can use http://csscomb.com/config to easily generate a config file.
+Config file. Can be built-in config (`csscomb`, `zen`, or `yandex`), path to a config file, or an object containing custom configuration. 
 
 > **Warning!**
 >


### PR DESCRIPTION
### What is the purpose of this pull request?

Currently on the VSCode extension page, there's not much info in the Usage section on how to get started. There's also a lack of info in csscomb.preset about the predefined configs and how to use them.

The changes here can help lower the barrier of entry for new users. 

### What changes did you make? (Give an overview)
- Usage: added a step on how to set up a config file
- csscomb.preset: added an example, and reworded description on what values this option takes


