### PR TITLE
Add support for Svelte files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ See the [extension installation guide](https://code.visualstudio.com/docs/editor
 ## Supported languages
 
   * Styles: CSS, Less, Sass, SCSS
-  * Styles inside `<style>` or `<style lang="LANGUAGE">` tags: HTML, Vue
+  * Styles inside `<style>` or `<style lang="LANGUAGE">` tags: HTML, Vue, Svelte
 
-    > ⚠️ The plugin does not support formatting when saving template files (HTML, Vue) by `formatOnSave` option and formatting of the selected fragments (selections).
+    > ⚠️ The plugin does not support formatting when saving template files (HTML, Vue, Svelte) by `formatOnSave` option and formatting of the selected fragments (selections).
 
 ## Supported settings
 

--- a/src/providers/embedded.ts
+++ b/src/providers/embedded.ts
@@ -114,6 +114,6 @@ export default class EmbeddedProvider extends BaseProvider {
 	}
 
 	public supportedSyntaxes(): string[] {
-		return ['html', 'htm', 'vue', 'vue-html'];
+		return ['html', 'htm', 'vue', 'vue-html', 'svelte'];
 	}
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

Similar to Vue.js, [Svelte](https://svelte.dev) is also using inline `<style>` elements, so it can be assumed, that this plugin is able to handle those files without any further adjustments.

### What changes did you make? (Give an overview)

Support for Vue.js was already added in https://github.com/mrmlnc/vscode-csscomb/pull/73. I just added `svelte` to the array of supported syntaxes and updated the Readme.
